### PR TITLE
refactor: import sass:map instead of deprecated map-get global

### DIFF
--- a/apps/app-2/src/app/sass/header.scss
+++ b/apps/app-2/src/app/sass/header.scss
@@ -1,3 +1,4 @@
+@use 'sass:map' as map;
 @use 'node_modules/govuk-frontend/dist/govuk/settings/_colours-applied.scss' as colors;
 @use 'node_modules/govuk-frontend/dist/govuk/helpers/media-queries' as mixins;
 @use 'node_modules/govuk-frontend/dist/govuk/settings/media-queries' as settings;
@@ -15,7 +16,7 @@ $pins-colours-teal-100: #10847e;
 }
 
 .pins-header__navigation--align-right {
-	@include mixins.govuk-media-query($from: map-get(settings.$govuk-breakpoints, 'desktop')) {
+	@include mixins.govuk-media-query($from: map.get(settings.$govuk-breakpoints, 'desktop')) {
 		float: right;
 	}
 }


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
