### PR TITLE
Feat/govuk frontend changes

### DIFF
--- a/apps/manage/src/app/views/layouts/forms-representation-check-your-answers.njk
+++ b/apps/manage/src/app/views/layouts/forms-representation-check-your-answers.njk
@@ -32,7 +32,7 @@
             right: 0;
         }
         .app-task-list .govuk-summary-list {
-            border-top: 1px solid #b1b4b6;
+            border-top: 1px solid #cecece;
         }
     </style>
 

--- a/apps/manage/src/app/views/layouts/main.njk
+++ b/apps/manage/src/app/views/layouts/main.njk
@@ -22,7 +22,7 @@
 	{{ header(config.headerTitle) }}
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 	<script {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>
 		document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 	</script>

--- a/apps/portal/src/app/views/layouts/main.njk
+++ b/apps/portal/src/app/views/layouts/main.njk
@@ -23,7 +23,7 @@
 	{% include "views/layouts/components/core/header.njk" %}
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 	<script {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>
 		document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 	</script>

--- a/packages/lib/app/app.ts
+++ b/packages/lib/app/app.ts
@@ -51,7 +51,6 @@ export function createBaseApp({
 		const nunjucksEnvironment = configureNunjucks();
 		// Set the express view engine to nunjucks
 		// calls to res.render will use nunjucks
-		nunjucksEnvironment.addGlobal('govukRebrand', true);
 		nunjucksEnvironment.express(app);
 		app.set('view engine', 'njk');
 	}

--- a/packages/lib/ui/brand/pins-colors.scss
+++ b/packages/lib/ui/brand/pins-colors.scss
@@ -1,8 +1,9 @@
 @use 'sass:map' as map;
+@use 'node_modules/govuk-frontend/dist/govuk/index' as govuk;
 @use 'node_modules/govuk-frontend/dist/govuk/settings/colours-organisations' as org-colors;
 
-$pins-grey-100: #f3f2f1;
-$pins-blue-500: #1d70b8;
+$pins-grey-100: govuk.govuk-colour('black', $variant: 'tint-95');
+$pins-blue-500: govuk.govuk-colour('blue');
 $pins-green-200: #13a19b;
 $pins-green-strip: #00625e;
 $pins-mhclg-green: map.get(

--- a/packages/lib/ui/brand/pins-colors.scss
+++ b/packages/lib/ui/brand/pins-colors.scss
@@ -5,7 +5,6 @@
 $pins-grey-100: govuk.govuk-colour('black', $variant: 'tint-95');
 $pins-blue-500: govuk.govuk-colour('blue');
 $pins-green-200: #13a19b;
-$pins-green-strip: #00625e;
 $pins-mhclg-green: map.get(
 	org-colors.$govuk-colours-organisations,
 	'ministry-of-housing-communities-local-government',

--- a/packages/lib/ui/header/pins-header.scss
+++ b/packages/lib/ui/header/pins-header.scss
@@ -23,7 +23,7 @@ header.govuk-header.pins-header {
 	& svg {
 		height: 40px;
 		& rect {
-			fill: brand.$pins-green-strip;
+			fill: brand.$pins-mhclg-green;
 		}
 	}
 }

--- a/packages/lib/ui/header/pins-header.scss
+++ b/packages/lib/ui/header/pins-header.scss
@@ -8,14 +8,14 @@ header.govuk-header.pins-header {
 	border-bottom: 0.5rem solid brand.$pins-green-200;
 
 	&.pins-header__external {
-		color: white;
+		color: govuk.govuk-colour('white');
 		background-color: brand.$pins-mhclg-green;
 		font-family: govuk.$govuk-font-family;
 
 		& svg {
-			fill: white;
+			fill: govuk.govuk-colour('white');
 			& rect {
-				fill: white;
+				fill: govuk.govuk-colour('white');
 			}
 		}
 	}
@@ -33,15 +33,15 @@ header.govuk-header.pins-header {
 	border-bottom: none;
 
 	& .govuk-service-navigation__item {
-		border-color: black;
+		border-color: govuk.govuk-colour('black');
 	}
 
 	& .govuk-service-navigation__link {
-		color: black;
-		border-bottom-color: black;
+		color: govuk.govuk-colour('black');
+		border-bottom-color: govuk.govuk-colour('black');
 	}
 
 	& .govuk-service-navigation__link:hover {
-		color: black;
+		color: govuk.govuk-colour('black');
 	}
 }


### PR DESCRIPTION
## Describe your changes
Changed required for compatibility with `govuk-frontend@6.0.0`:

1. Change deprecated `beforeContent` block name to `containerStart`
2. Replace deprecated greys `#b1b4b6` `#f3f2f1` with suggested replacements
3. Remove deprecated rebrand feature flag from nunjucks environment

See https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0

Additional fixes:

1. Use `govuk` colour definitions in pins colour definitions where possible
2. Remove double definition of MHCLG green colour
3. Replace CSS named colours with `govuk` colour definitions. There is no effective change to `white`, but `black` in `govuk` is `#0b0c0c`, not `#000000`. This also means that any future changes will not be missed.

## Issue ticket number and link
N/A
