### PR TITLE
Fix/footer issues

### DIFF
--- a/packages/lib/ui/footer/pins-footer.njk
+++ b/packages/lib/ui/footer/pins-footer.njk
@@ -1,5 +1,5 @@
 {% macro pinsFooter(footerLinks) %}
-    <footer class="pins-footer" role="contentinfo">
+    <footer class="pins-footer">
         <div class="pins-footer-row">
             <div class="pins-footer-container govuk-width-container">
                 <div class="govuk-footer__meta">

--- a/packages/lib/ui/footer/pins-footer.njk
+++ b/packages/lib/ui/footer/pins-footer.njk
@@ -3,7 +3,7 @@
         <div class="pins-footer-row">
             <div class="pins-footer-container govuk-width-container">
                 <div class="govuk-footer__meta">
-                    <div>
+                    <div class="govuk-footer__meta-item">
                         <ul class="govuk-footer__inline-list">
                             {% for footerLink in footerLinks %}
                                 <li class="govuk-footer__inline-list-item">
@@ -12,7 +12,7 @@
                             {% endfor %}
                         </ul>
                     </div>
-                    <div>
+                    <div class="govuk-footer__meta-item">
                         <span class="govuk-footer__copyright">© Planning Inspectorate</span>
                     </div>
                 </div>

--- a/packages/lib/ui/footer/pins-footer.scss
+++ b/packages/lib/ui/footer/pins-footer.scss
@@ -6,7 +6,6 @@
 	border-top: 0.25rem solid brand.$pins-green-200;
 }
 .pins-footer-container {
-	margin: 0 auto;
 	padding: 1.25rem 0;
 	font-family: govuk.$govuk-font-family;
 	color: govuk.govuk-colour('black');

--- a/packages/lib/ui/footer/pins-footer.scss
+++ b/packages/lib/ui/footer/pins-footer.scss
@@ -16,16 +16,6 @@
 	justify-content: space-between;
 	align-items: center;
 }
-.govuk-footer__inline-list {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-	display: flex;
-	gap: 1.25rem;
-}
-.govuk-footer__inline-list-item {
-	display: inline;
-}
 .govuk-footer__link {
 	color: brand.$pins-blue-500;
 	text-decoration: underline;


### PR DESCRIPTION
## Describe your changes
1. Remove `role="contentinfo"` from `footer` since it has this role anyway and it causes a duplicate announcement in Narrator
2. Add `govuk-footer__meta-item` classes to ensure spacing between the items
3. Remove auto margin on `.pins-footer-container` as this causes zero margin on mobile viewports
4. Remove custom flex styling on `.govuk-footer__inline-list` as this doesn't wrap on mobile, and the default govuk styles appear to work better