### PR TITLE
fix(header): remove redundant styles

### DIFF
--- a/packages/lib/ui/header/pins-header.scss
+++ b/packages/lib/ui/header/pins-header.scss
@@ -32,16 +32,12 @@ header.govuk-header.pins-header {
 	background: brand.$pins-grey-100;
 	border-bottom: none;
 
-	& .govuk-service-navigation__item {
+	.govuk-service-navigation__item {
 		border-color: govuk.govuk-colour('black');
 	}
 
-	& .govuk-service-navigation__link {
-		color: govuk.govuk-colour('black');
-		border-bottom-color: govuk.govuk-colour('black');
-	}
-
-	& .govuk-service-navigation__link:hover {
+	.govuk-service-navigation__link,
+	.govuk-service-navigation__link:hover {
 		color: govuk.govuk-colour('black');
 	}
 }


### PR DESCRIPTION
## Describe your changes
When fixing a style bug relating to a previous version of the header template, I realised that overriding `border-bottom-color` on `govuk-service-navigation__link` is redundant - border colour is set on `item`, not `link`. I've removed that for clarity, and tidied up these navigation classes to be as minimal and clear as possible.

## Issue ticket number and link
N/A